### PR TITLE
Refactor DAO and fix frontend persistence + icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-.vscode/mcp.json
+# Ignore local SQLite DB used for development
+todo.db

--- a/src/main/java/com/example/dao/TaskDao.java
+++ b/src/main/java/com/example/dao/TaskDao.java
@@ -1,0 +1,166 @@
+package com.example.dao;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.sqlite.SQLiteDataSource;
+import java.util.ArrayList;
+import java.util.List;
+import com.example.model.Task;
+
+public class TaskDao {
+    /** Data access object for tasks backed by an embedded SQLite database. */
+    // Keep driver loading once per class
+    static {
+        try {
+            try {
+                Class.forName("org.sqlite.JDBC");
+                System.out.println("[TaskDao] org.sqlite.JDBC driver loaded");
+            } catch (ClassNotFoundException cnfe) {
+                System.err.println("[TaskDao] Class.forName failed for org.sqlite.JDBC: " + cnfe.getMessage());
+            }
+            try {
+                org.sqlite.JDBC driver = new org.sqlite.JDBC();
+                java.sql.DriverManager.registerDriver(driver);
+                System.out.println("[TaskDao] org.sqlite.JDBC driver instance registered");
+            } catch (Exception t) {
+                System.err.println("[TaskDao] Failed to register org.sqlite.JDBC driver instance: " + t.getMessage());
+                t.printStackTrace();
+            }
+        } catch (Exception e) {
+            System.err.println("[TaskDao] Failed to load org.sqlite.JDBC driver");
+            e.printStackTrace();
+        }
+    }
+
+    private final SQLiteDataSource ds;
+    private final String dbFilePath;
+
+    /**
+     * Default constructor kept for backward compatibility. Uses the project-local path.
+     */
+    public TaskDao() {
+        this("/Users/apple/my-webapp-project/todo.db");
+    }
+
+    /**
+     * Create a TaskDao that uses the given file path for the SQLite database.
+     * The caller should supply an absolute path (usually from servlet context).
+     */
+    public TaskDao(String dbFilePath) {
+        this.dbFilePath = dbFilePath;
+        String url = "jdbc:sqlite:" + dbFilePath;
+        ds = new SQLiteDataSource();
+        ds.setUrl(url);
+        System.out.println("[TaskDao] SQLiteDataSource configured with URL: " + url);
+
+        // Ensure the table exists
+        try (Connection conn = ds.getConnection()) {
+            String createTableSQL = "CREATE TABLE IF NOT EXISTS tasks (" +
+                                    "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+                                    "title TEXT NOT NULL, " +
+                                    "completed BOOLEAN NOT NULL DEFAULT 0)";
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute(createTableSQL);
+            }
+        } catch (SQLException e) {
+            System.err.println("[TaskDao] Failed to create or open DB at: " + dbFilePath);
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Retrieves all tasks from the database.
+     *
+     * @return a list of all Task objects in the database
+     */
+    public List<Task> getAllTasks() {
+        System.out.println("[TaskDao] getAllTasks called. DB path: " + dbFilePath);
+        List<Task> tasks = new ArrayList<>();
+        try (Connection conn = ds.getConnection();
+                 Statement stmt = conn.createStatement();
+                 ResultSet rs = stmt.executeQuery("SELECT id, title, completed FROM tasks")) {
+            while (rs.next()) {
+                Task t = new Task(rs.getInt("id"), rs.getString("title"), rs.getBoolean("completed"));
+                System.out.println("[TaskDao] fetched: id=" + t.getId() + ", title=" + t.getTitle() + ", completed=" + t.isCompleted());
+                tasks.add(t);
+            }
+        } catch (SQLException e) {
+            System.err.println("[TaskDao] getAllTasks failed for DB: " + dbFilePath);
+            e.printStackTrace();
+        }
+        System.out.println("[TaskDao] getAllTasks returning " + tasks.size() + " tasks.");
+        return tasks;
+    }
+
+    public Task addTask(String title) {
+        System.out.println("[TaskDao] addTask called with title: " + title + ". DB path: " + dbFilePath);
+        String sql = "INSERT INTO tasks (title) VALUES (?)";
+        try (Connection conn = ds.getConnection();
+             PreparedStatement pstmt = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            pstmt.setString(1, title);
+            int affected = pstmt.executeUpdate();
+            System.out.println("[TaskDao] Rows inserted: " + affected);
+            try (ResultSet generatedKeys = pstmt.getGeneratedKeys()) {
+                if (generatedKeys.next()) {
+                    int id = generatedKeys.getInt(1);
+                    System.out.println("[TaskDao] Inserted task id: " + id);
+                    return new Task(id, title, false);
+                }
+            }
+        } catch (SQLException e) {
+            System.err.println("[TaskDao] addTask failed for DB: " + dbFilePath + ", title=" + title);
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    /**
+     * Update only the completed status for backward compatibility.
+     */
+    public void updateTask(int id, boolean completed) {
+        updateTask(id, null, completed);
+    }
+
+    /**
+     * Update a task's title and completion status.
+     */
+    public void updateTask(int id, String title, boolean completed) {
+        String sql;
+        boolean updateTitle = title != null && !title.isEmpty();
+        if (updateTitle) {
+            sql = "UPDATE tasks SET title = ?, completed = ? WHERE id = ?";
+        } else {
+            sql = "UPDATE tasks SET completed = ? WHERE id = ?";
+        }
+        try (Connection conn = ds.getConnection();
+             PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            if (updateTitle) {
+                pstmt.setString(1, title);
+                pstmt.setBoolean(2, completed);
+                pstmt.setInt(3, id);
+            } else {
+                pstmt.setBoolean(1, completed);
+                pstmt.setInt(2, id);
+            }
+            pstmt.executeUpdate();
+        } catch (SQLException e) {
+            System.err.println("[TaskDao] updateTask failed for DB: " + dbFilePath + ", id=" + id + ", title=" + title);
+            e.printStackTrace();
+        }
+    }
+
+    public void deleteTask(int id) {
+        String sql = "DELETE FROM tasks WHERE id = ?";
+        try (Connection conn = ds.getConnection();
+             PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            pstmt.setInt(1, id);
+            pstmt.executeUpdate();
+        } catch (SQLException e) {
+            System.err.println("[TaskDao] deleteTask failed for DB: " + dbFilePath + ", id=" + id);
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/com/example/servlet/TasksServlet.java
+++ b/src/main/java/com/example/servlet/TasksServlet.java
@@ -1,0 +1,99 @@
+package com.example.servlet;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.List;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import com.google.gson.Gson;
+import com.example.dao.TaskDao;
+import com.example.model.Task;
+
+/** Servlet exposing basic CRUD API for Tasks. */
+@WebServlet("/api/tasks/*")
+public class TasksServlet extends HttpServlet {
+    private transient TaskDao taskDao;
+    private transient final Gson gson = new Gson();
+    private static final String APPLICATION_JSON = "application/json";
+
+    @Override
+    public void init() throws ServletException {
+        super.init();
+        // Prefer storing DB inside WEB-INF so the container user can write to it
+        String dbRelPath = "/WEB-INF/todo.db";
+        String dbFilePath = getServletContext().getRealPath(dbRelPath);
+        if (dbFilePath == null) {
+            // getRealPath may return null in some container setups (exploded war not used)
+            dbFilePath = System.getProperty("java.io.tmpdir") + "/todo.db";
+            System.err.println("[TasksServlet] getRealPath returned null; using temp file: " + dbFilePath);
+        }
+        System.out.println("[TasksServlet] Initializing TaskDao with DB file: " + dbFilePath);
+        taskDao = new TaskDao(dbFilePath);
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        List<Task> tasks = taskDao.getAllTasks();
+        resp.setContentType(APPLICATION_JSON);
+        PrintWriter out = resp.getWriter();
+        out.print(gson.toJson(tasks));
+        out.flush();
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        String title = req.getParameter("title");
+        if (title != null && !title.isEmpty()) {
+            Task newTask = taskDao.addTask(title);
+            if (newTask != null) {
+                resp.setContentType(APPLICATION_JSON);
+                resp.setStatus(HttpServletResponse.SC_CREATED);
+                PrintWriter out = resp.getWriter();
+                out.print(gson.toJson(newTask));
+                out.flush();
+            } else {
+                // DB insert failed; return 500 and log for easier debugging
+                System.err.println("[TasksServlet] Failed to create task for title='" + title + "' - TaskDao returned null");
+                resp.setContentType(APPLICATION_JSON);
+                resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+                PrintWriter out = resp.getWriter();
+                out.print("{\"error\":\"Failed to create task on server\"}");
+                out.flush();
+            }
+        } else {
+            resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        }
+    }
+
+    @Override
+    protected void doPut(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        String pathInfo = req.getPathInfo();
+        if (pathInfo != null && pathInfo.length() > 1) {
+            int id = Integer.parseInt(pathInfo.substring(1));
+            String title = req.getParameter("title");
+            boolean completed = Boolean.parseBoolean(req.getParameter("completed"));
+            if (title == null) title = ""; // avoid NPE in DAO
+            taskDao.updateTask(id, title, completed);
+            resp.setStatus(HttpServletResponse.SC_OK);
+        } else {
+            resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        }
+    }
+
+    @Override
+    protected void doDelete(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        String pathInfo = req.getPathInfo();
+        if (pathInfo != null && pathInfo.length() > 1) {
+            int id = Integer.parseInt(pathInfo.substring(1));
+            taskDao.deleteTask(id);
+            resp.setStatus(HttpServletResponse.SC_NO_CONTENT);
+        } else {
+            resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        }
+    }
+}

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -1,9 +1,12 @@
+<%@ page pageEncoding="UTF-8" contentType="text/html; charset=UTF-8" %>
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Beautified Hello World</title>
+    <!-- Bootstrap Icons CDN (small, no JS needed) -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
     <style>
         /* Modern ve temiz bir font ailesi seçtik */
         body {
@@ -45,8 +48,151 @@
 </head>
 <body>
     <div class="container">
-        <h2>Hello World!</h2>
-        <p>This page has been officially beautified.</p>
+        <h2>To Do List</h2>
+        <form id="add-task-form" style="margin-bottom: 2rem; display: flex; gap: 1rem; justify-content: center; align-items: center;">
+            <input id="new-task-title" type="text" placeholder="Add a new task..." required style="padding: 0.5rem 1rem; border-radius: 8px; border: none; width: 250px; font-size: 1rem;">
+            <button type="submit" style="padding: 0.5rem 1.5rem; border-radius: 8px; border: none; background: #667eea; color: white; font-weight: bold; cursor: pointer;">Add</button>
+        </form>
+        <ul id="task-list" style="list-style: none; padding: 0; margin: 0; max-width: 400px; margin-left: auto; margin-right: auto;"></ul>
     </div>
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+        // Helper to get context path dynamically
+        function getApiUrl(path) {
+            const ctx = window.location.pathname.split('/')[1];
+            return `/${ctx}/` + path.replace(/^\//, '');
+        }
+
+        async function fetchTasks() {
+            try {
+                const res = await fetch(getApiUrl('api/tasks'));
+                if (!res.ok) throw new Error('Failed to fetch tasks');
+                const tasks = await res.json();
+                renderTasks(tasks);
+            } catch (e) {
+                alert('Error loading tasks: ' + e.message);
+            }
+        }
+
+        function renderTasks(tasks) {
+            const list = document.getElementById('task-list');
+            list.innerHTML = '';
+            tasks.forEach(task => {
+                const li = document.createElement('li');
+                li.style.display = 'flex';
+                li.style.alignItems = 'center';
+                li.style.justifyContent = 'space-between';
+                li.style.background = 'rgba(255,255,255,0.15)';
+                li.style.marginBottom = '0.5rem';
+                li.style.padding = '0.75rem 1rem';
+                li.style.borderRadius = '10px';
+
+                // Checkbox
+                const checkbox = document.createElement('input');
+                checkbox.type = 'checkbox';
+                checkbox.checked = task.completed;
+                checkbox.style.marginRight = '1rem';
+                checkbox.onchange = () => updateTask(task.id, task.title, checkbox.checked);
+
+                // Title (editable)
+                const title = document.createElement('span');
+                title.textContent = task.title;
+                title.style.flex = '1';
+                title.style.textDecoration = task.completed ? 'line-through' : 'none';
+                title.style.opacity = task.completed ? '0.6' : '1';
+
+                // Edit (pen) icon
+                const editBtn = document.createElement('button');
+                editBtn.innerHTML = '<i class="bi bi-pencil" aria-hidden="true"></i>';
+                editBtn.title = 'Edit';
+                editBtn.style.background = 'none';
+                editBtn.style.border = 'none';
+                editBtn.style.cursor = 'pointer';
+                editBtn.style.marginLeft = '0.5rem';
+                editBtn.onclick = () => {
+                    const newTitle = prompt('Update task:', task.title);
+                    if (newTitle && newTitle !== task.title) {
+                        updateTask(task.id, newTitle, task.completed);
+                    }
+                };
+
+                // Delete (trash) icon
+                const deleteBtn = document.createElement('button');
+                deleteBtn.innerHTML = '<i class="bi bi-trash" aria-hidden="true"></i>';
+                deleteBtn.title = 'Delete';
+                deleteBtn.style.background = 'none';
+                deleteBtn.style.border = 'none';
+                deleteBtn.style.cursor = 'pointer';
+                deleteBtn.style.marginLeft = '0.5rem';
+                deleteBtn.onclick = () => deleteTask(task.id);
+
+                li.appendChild(checkbox);
+                li.appendChild(title);
+                li.appendChild(editBtn);
+                li.appendChild(deleteBtn);
+                list.appendChild(li);
+            });
+        }
+
+        async function addTask(title) {
+            try {
+                const res = await fetch(getApiUrl('api/tasks'), {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                    body: 'title=' + encodeURIComponent(title)
+                });
+                if (!res.ok) {
+                    const text = await res.text();
+                    throw new Error('Server error: ' + res.status + ' ' + text);
+                }
+                fetchTasks();
+            } catch (e) {
+                alert('Error adding task: ' + e.message);
+            }
+        }
+
+        async function updateTask(id, title, completed) {
+            try {
+                // Use path-based id and query params so servlet can read them reliably
+                const url = getApiUrl(`api/tasks/${id}?completed=${completed}&title=${encodeURIComponent(title)}`);
+                const res = await fetch(url, { method: 'PUT' });
+                if (!res.ok) {
+                    const text = await res.text();
+                    throw new Error('Server error: ' + res.status + ' ' + text);
+                }
+                fetchTasks();
+            } catch (e) {
+                alert('Error updating task: ' + e.message);
+            }
+        }
+
+        async function deleteTask(id) {
+            try {
+                const url = getApiUrl(`api/tasks/${id}`);
+                const res = await fetch(url, { method: 'DELETE' });
+                if (!res.ok) {
+                    const text = await res.text();
+                    throw new Error('Server error: ' + res.status + ' ' + text);
+                }
+                fetchTasks();
+            } catch (e) {
+                alert('Error deleting task: ' + e.message);
+            }
+        }
+
+        document.getElementById('add-task-form').onsubmit = function(e) {
+            e.preventDefault();
+            const input = document.getElementById('new-task-title');
+            const title = input.value.trim();
+            if (title) {
+                addTask(title);
+                input.value = '';
+            }
+        };
+
+        // Load tasks on page load
+        fetchTasks();
+    });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
This PR refactors `TaskDao` to accept a servlet-context DB path, improves error handling in `TasksServlet`, fixes frontend UTF-8/encoding and replaces emoji icons with Bootstrap Icons. Also ignores local `todo.db` in `.gitignore`.

Changes:
- `TaskDao` now constructed with an absolute DB file path and ensures table creation.
- `TasksServlet` initializes `TaskDao` from `getServletContext().getRealPath` (with tmp fallback) and returns 500 on DB insert failures.
- `index.jsp` adds UTF-8 directive and uses Bootstrap Icons; frontend PUT/DELETE use path-based endpoints for reliability.

Please review and merge.